### PR TITLE
Add optional type filter for items

### DIFF
--- a/src/item/dto/item.dto.ts
+++ b/src/item/dto/item.dto.ts
@@ -4,7 +4,11 @@ import { IsOptional, IsString, IsDecimal, IsUUID, IsEnum } from "class-validator
 import { HasMimeType, IsFile, MemoryStoredFile } from "nestjs-form-data";
 import { ItemType } from "@app/item/interfaces/item.interface";
 
-export class ItemParamDto extends IntersectionType(ParamsDto) {}
+export class ItemParamDto extends IntersectionType(ParamsDto) {
+    @IsOptional()
+    @IsEnum(ItemType)
+    public type?: number;
+}
 
 export class ItemCreateDto {
     @IsString()

--- a/src/item/item.service.ts
+++ b/src/item/item.service.ts
@@ -1,5 +1,5 @@
 import { HttpException, Injectable } from "@nestjs/common";
-import { Prisma, Files as FileModel } from "@prisma/client";
+import { Files as FileModel, Prisma } from "@prisma/client";
 import { FavoriteParamsDto, ItemCreateDto, ItemParamDto, ItemUpdateDto } from "./dto/item.dto";
 import { AuthContextService } from "@app/auth/auth-context.service";
 import { FileService } from "@app/file/file.service";
@@ -117,6 +117,9 @@ export class ItemService {
             take: params?.limit ?? 30,
             skip: params?.offset,
             orderBy: { id: params?.order_by ?? "desc" },
+            where: {
+                type: params?.type,
+            },
         });
         return results.map((item) => new ItemEntity(item));
     }
@@ -154,7 +157,7 @@ export class ItemService {
         const items = await this.getItems(params);
 
         if (!userId) {
-            const itemsWithImages = await Promise.all(
+            return await Promise.all(
                 items.map(async (item) => {
                     return await this.createItemEntityWithExtras(item, {
                         isFavorite: false,
@@ -162,13 +165,12 @@ export class ItemService {
                     });
                 }),
             );
-            return itemsWithImages;
         }
 
         const favorites = await this.getFavorites(userId, { limit: 1000 });
         const favoriteItemIds = new Set(favorites.map((fav) => fav.item_id));
 
-        const itemsWithFavoritesAndImages = await Promise.all(
+        return await Promise.all(
             items.map(async (item) => {
                 const isFavorite = favoriteItemIds.has(item.id);
                 return await this.createItemEntityWithExtras(item, {
@@ -177,8 +179,6 @@ export class ItemService {
                 });
             }),
         );
-
-        return itemsWithFavoritesAndImages;
     }
 
     public async findItemByIdWithFavoriteInfo(


### PR DESCRIPTION
### What does this implement/fix?

- Added an optional `type` filter in `ItemParamDto` to allow filtering items by type.
- Refactored and optimized item entity mapping logic by removing redundant variables.

### Why is this change needed?

This change improves the flexibility of item queries and enhances code maintainability by simplifying the mapping logic.