### PR TITLE
feature/PPM-64

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { JwtModule } from "@nestjs/jwt";
 import { AuthController } from "./auth.controller";
 import { PassportModule } from "@nestjs/passport";
 import { JwtStrategy } from "./strategies/jwt.strategy";
+import { OptionalJwtStrategy } from "./strategies/optional-jwt.strategy";
 import { LocalStrategy } from "./strategies/local.strategy";
 import { RefreshJwtStrategy } from "./strategies/refresh-jwt.strategy";
 import { ParameterModule } from "@app/parameter/parameter.module";
@@ -16,7 +17,14 @@ import { AuthContextService } from "./auth-context.service";
 
 @Global()
 @Module({
-    providers: [AuthService, JwtStrategy, LocalStrategy, RefreshJwtStrategy, AuthContextService],
+    providers: [
+        AuthService,
+        JwtStrategy,
+        OptionalJwtStrategy,
+        LocalStrategy,
+        RefreshJwtStrategy,
+        AuthContextService,
+    ],
     imports: [
         UserModule,
         ParameterModule,

--- a/src/auth/guards/optional-jwt.guard.ts
+++ b/src/auth/guards/optional-jwt.guard.ts
@@ -1,0 +1,21 @@
+import { ExecutionContext, Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard("jwt") {
+    public canActivate(context: ExecutionContext): boolean {
+        try {
+            return super.canActivate(context) as boolean;
+        } catch {
+            return true;
+        }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public handleRequest(err: any, user: any): any {
+        if (err || !user) {
+            return null;
+        }
+        return user;
+    }
+}

--- a/src/auth/guards/optional-jwt.guard.ts
+++ b/src/auth/guards/optional-jwt.guard.ts
@@ -1,8 +1,9 @@
 import { ExecutionContext, Injectable } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
+import { TokenPayload } from "../interfaces/auth.interface";
 
 @Injectable()
-export class OptionalJwtAuthGuard extends AuthGuard("jwt") {
+export class OptionalJwtAuthGuard extends AuthGuard("optional-jwt") {
     public canActivate(context: ExecutionContext): boolean {
         try {
             return super.canActivate(context) as boolean;
@@ -11,10 +12,12 @@ export class OptionalJwtAuthGuard extends AuthGuard("jwt") {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public handleRequest(err: any, user: any): any {
+    public handleRequest<TUser = TokenPayload | null>(
+        err: Error | null,
+        user: TUser,
+    ): TUser | null {
         if (err || !user) {
-            return null;
+            return null as TUser | null;
         }
         return user;
     }

--- a/src/auth/strategies/optional-jwt.strategy.ts
+++ b/src/auth/strategies/optional-jwt.strategy.ts
@@ -1,0 +1,37 @@
+import { Injectable } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import { ExtractJwt, Strategy } from "passport-jwt";
+import { TokenPayload } from "../interfaces/auth.interface";
+import { ConfigService } from "@nestjs/config";
+import jwtConfig from "../../configs/jwt.config";
+import { AuthContextService } from "../auth-context.service";
+import { ContextIdFactory, ModuleRef } from "@nestjs/core";
+
+@Injectable()
+export class OptionalJwtStrategy extends PassportStrategy(Strategy, "optional-jwt") {
+    public constructor(
+        private moduleRef: ModuleRef,
+        private configService: ConfigService<typeof jwtConfig, true>,
+    ) {
+        const secret = configService.get<string>("jwt.secret", { infer: true });
+
+        super({
+            jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+            ignoreExpiration: false,
+            secretOrKey: secret,
+            passReqToCallback: true,
+        });
+    }
+
+    public async validate(request: Request, payload: TokenPayload): Promise<TokenPayload | null> {
+        try {
+            const contextId = ContextIdFactory.getByRequest(request);
+            const authContextService = await this.moduleRef.resolve(AuthContextService, contextId);
+            await authContextService.generateAuthContext(payload.id);
+            return payload;
+        } catch {
+            // Si falla la validación, retorna null sin lanzar error
+            return null;
+        }
+    }
+}

--- a/src/item/item.controller.ts
+++ b/src/item/item.controller.ts
@@ -16,6 +16,7 @@ import {
 import { ItemService } from "./item.service";
 import { FormDataRequest } from "nestjs-form-data";
 import { JwtAuthGuard } from "@app/auth/guards/jwt.guard";
+import { OptionalJwtAuthGuard } from "@app/auth/guards/optional-jwt.guard";
 import { FavoriteParamsDto, ItemCreateDto, ItemParamDto, ItemUpdateDto } from "./dto/item.dto";
 import { ItemEntity } from "./entities/item.entity";
 import { FavoriteEntity } from "./entities/favorite.entity";
@@ -72,40 +73,33 @@ export class ItemController {
         return await this.itemService.getProviderItems(params);
     }
 
+    @UseGuards(OptionalJwtAuthGuard)
     @GetItemsDocumentation()
     @Get()
-    public async getItems(@Query() params: ItemParamDto): Promise<ItemEntity[]> {
+    public async getItems(
+        @Query() params: ItemParamDto,
+        @Req() req: Request & { user?: TokenPayload },
+    ): Promise<ItemEntity[]> {
+        if (req.user) {
+            return await this.itemService.getItemsWithFavoriteInfo(params, req.user.id);
+        }
         return await this.itemService.getItemsPublic(params);
     }
 
-    @UseGuards(JwtAuthGuard)
-    @Get("authenticated")
-    public async getItemsAuthenticated(
-        @Query() params: ItemParamDto,
-        @Req() req: Request & { user: TokenPayload },
-    ): Promise<ItemEntity[]> {
-        return await this.itemService.getItemsWithFavoriteInfo(params, req.user.id);
-    }
-
+    @UseGuards(OptionalJwtAuthGuard)
     @GetItemDocumentation()
     @Get(":id")
-    public async getItemById(@Param() params: { id: string }): Promise<ItemEntity> {
-        const item = await this.itemService.findItemByIdPublic(params.id);
-
-        if (!item) {
-            throw new HttpException("Item not found", 404);
-        }
-
-        return item;
-    }
-
-    @UseGuards(JwtAuthGuard)
-    @Get(":id/authenticated")
-    public async getItemByIdAuthenticated(
+    public async getItemById(
         @Param() params: { id: string },
-        @Req() req: Request & { user: TokenPayload },
+        @Req() req: Request & { user?: TokenPayload },
     ): Promise<ItemEntity> {
-        const item = await this.itemService.findItemByIdWithFavoriteInfo(params.id, req.user.id);
+        let item: ItemEntity | null;
+
+        if (req.user) {
+            item = await this.itemService.findItemByIdWithFavoriteInfo(params.id, req.user.id);
+        } else {
+            item = await this.itemService.findItemByIdPublic(params.id);
+        }
 
         if (!item) {
             throw new HttpException("Item not found", 404);

--- a/src/provider/provider.controller.ts
+++ b/src/provider/provider.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ProviderService } from "@app/provider/provider.service";
 import { ApiTags } from "@nestjs/swagger";
 import { ProvidersParamsDto } from "./dto/params.dto";
+import { OptionalJwtAuthGuard } from "@app/auth/guards/optional-jwt.guard";
 import {
     GetProviderDocumention,
     GetProvidersDocumentation,
@@ -25,11 +26,15 @@ import { JwtAuthGuard } from "@app/auth/guards/jwt.guard";
 import { FormDataRequest } from "nestjs-form-data";
 import { TokenPayload } from "@app/auth/interfaces/auth.interface";
 import { Request } from "express";
+import { AuthContextService } from "@app/auth/auth-context.service";
 
 @ApiTags("Provider")
 @Controller("providers")
 export class ProviderController {
-    public constructor(private providerService: ProviderService) {}
+    public constructor(
+        private providerService: ProviderService,
+        private authContextService: AuthContextService,
+    ) {}
 
     @UseInterceptors(ClassSerializerInterceptor)
     @GetProvidersDocumentation()
@@ -40,15 +45,37 @@ export class ProviderController {
     }
 
     @UseInterceptors(ClassSerializerInterceptor)
+    @UseGuards(OptionalJwtAuthGuard)
     @GetProviderDocumention()
     @Get(":id")
-    public async getProviderById(@Param() params: { id: string }): Promise<ProviderEntity> {
+    public async getProviderById(
+        @Param() params: { id: string },
+        @Req() req: Request & { user?: TokenPayload },
+    ): Promise<ProviderEntity> {
         const provider = await this.providerService.getProviderById(params.id);
 
         if (!provider) {
             throw new HttpException("Provider not found", 404);
         }
 
+        if (req.user) {
+            try {
+                const userProvider = this.authContextService.getProvider();
+                if (userProvider && userProvider.id === params.id) {
+                    return new ProviderEntity({
+                        ...provider,
+                        rut: provider.rut,
+                        chamber_commerce: provider.chamber_commerce,
+                        plan_id: provider.plan_id,
+                        user_id: provider.user_id,
+                        created_at: provider.created_at,
+                        updated_at: provider.updated_at,
+                    });
+                }
+            } catch {
+                // Si falla el contexto, continuar con versión pública
+            }
+        }
         return new ProviderEntity(provider);
     }
 

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -11,7 +11,10 @@ export class QuoteService {
         private authContextService: AuthContextService,
     ) {}
 
-    public async create(createDto: CreateQuoteDto): Promise<QuoteModel> {
+    public async create(
+        createDto: CreateQuoteDto,
+        authenticatedUserId?: string,
+    ): Promise<QuoteModel> {
         const providerExists = await this.quotePrismaRepository.findProviderById(
             createDto.provider_id,
         );
@@ -19,12 +22,15 @@ export class QuoteService {
             throw new HttpException("Provider not found", HttpStatus.NOT_FOUND);
         }
 
-        let userId: string | null = null;
-        try {
-            const user = this.authContextService.getUser();
-            userId = user.id;
-        } catch {
-            console.log("Anonymous user creating quote");
+        let userId: string | null = authenticatedUserId ?? null;
+
+        if (!userId) {
+            try {
+                const user = this.authContextService.getUser();
+                userId = user.id;
+            } catch {
+                console.log("Anonymous user creating quote");
+            }
         }
 
         const quoteData: Prisma.QuotesCreateInput = {


### PR DESCRIPTION
# Implementar OptionalAuthGuard y unificar endpoints duplicados

## Problema
- Múltiples endpoints haciendo lo mismo (`/items` vs `/items/authenticated`)
- No hay forma de incluir datos personalizados según autenticación
- Demasiados endpoints para una sola funcionalidad

## Solución
- **OptionalJwtAuthGuard**: Permite endpoints con/sin autenticación
- **Endpoints unificados**: Un endpoint que adapta respuesta según usuario
- **Datos contextuales**: Favoritos y campos privados solo si está autenticado

## Cambios
- Nuevos: `OptionalJwtAuthGuard`, `OptionalJwtStrategy`
- Refactorizados: `ItemController`, `ProviderController`, `QuoteController`
- Eliminados: `/items/authenticated`, `/items/:id/authenticated`