### PR TITLE
Update `ItemType` and `type` field to use strings instead of integers

### DIFF
--- a/prisma/schema/items.prisma
+++ b/prisma/schema/items.prisma
@@ -4,7 +4,7 @@ model Items {
   id          String    @id @default(uuid())
   name        String
   description String?
-  type        Int       @default(1)
+  type        String    @default("PRODUCT")
   price       Decimal   @default(0.00) @db.Decimal(10, 2)
   image       String?
   created_at  DateTime  @default(now())

--- a/src/item/dto/item.dto.ts
+++ b/src/item/dto/item.dto.ts
@@ -7,7 +7,12 @@ import { ItemType } from "@app/item/interfaces/item.interface";
 export class ItemParamDto extends IntersectionType(ParamsDto) {
     @IsOptional()
     @IsEnum(ItemType)
-    public type?: number;
+    @ApiProperty({
+        description: "Tipo de producto",
+        example: "PRODUCT",
+        enum: ItemType,
+    })
+    public type?: string;
 }
 
 export class ItemCreateDto {
@@ -18,8 +23,14 @@ export class ItemCreateDto {
     @IsString()
     public description?: string;
 
+    @ApiProperty({
+        description: "Tipo de producto",
+        example: "PRODUCT",
+        enum: ItemType,
+    })
+    @IsString()
     @IsEnum(ItemType)
-    public type: number;
+    public type: string;
 
     @IsDecimal({ decimal_digits: "2" })
     @IsOptional()

--- a/src/item/entities/item.entity.ts
+++ b/src/item/entities/item.entity.ts
@@ -13,6 +13,7 @@ export class ItemEntity {
     public updated_at: Date;
     public provider_id: string;
     public image_url: string | null;
+    public type: string;
 
     @ApiProperty({
         description: "Indicates if the item is marked as favorite by the current user",

--- a/src/item/interfaces/item.interface.ts
+++ b/src/item/interfaces/item.interface.ts
@@ -1,4 +1,4 @@
 export enum ItemType {
-    PRODUCT = 1,
-    SERVICE = 2,
+    PRODUCT = "PRODUCT",
+    SERVICE = "SERVICE",
 }


### PR DESCRIPTION
- Refactor `ItemType` enum to use string values ("PRODUCT", "SERVICE") instead of integers.
- Update DTOs and entities to reflect the change in `type` field.
- Modify Prisma schema to set `type` field as `String` with default value "PRODUCT".